### PR TITLE
Adjust the cmatrix install script to not run if running in a GitHub Codespace

### DIFF
--- a/script/install.d/81-cmatrix.sh
+++ b/script/install.d/81-cmatrix.sh
@@ -5,10 +5,15 @@
 #   Install cmatrix.
 #
 
-if ! command -v "cmatrix" &>/dev/null; then
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        sudo apt-get install -qq cmatrix &>/dev/null
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        brew install cmatrix
+# Check if running in a GitHub Codespace
+if [ -n "$CODESPACES" ]; then
+    echo "Skipping cmatrix installation: Running in a GitHub Codespace"
+else
+    if ! command -v "cmatrix" &>/dev/null; then
+        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            sudo apt-get install -qq cmatrix &>/dev/null
+        elif [[ "$OSTYPE" == "darwin"* ]]; then
+            brew install cmatrix
+        fi
     fi
 fi


### PR DESCRIPTION
Add a check to skip `cmatrix` installation if running in a GitHub Codespace.

* **Check for GitHub Codespace**: Add a check for the `CODESPACES` environment variable at the beginning of the script.
* **Skip Installation**: Skip the installation of `cmatrix` if the `CODESPACES` environment variable is set.
* **Informative Message**: Add a message indicating that the installation is being skipped due to running in a GitHub Codespace.