### PR TITLE
Add AppCleaner to macOS install

### DIFF
--- a/script/install.d/76-appcleaner.sh
+++ b/script/install.d/76-appcleaner.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# -----------------------------------------------------------------------------
+# Description:
+#   (macOS only) Install AppCleaner.
+#
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if ! brew list --cask appcleaner &> /dev/null; then
+        brew install --cask appcleaner
+        echo "AppCleaner has been installed."
+    else
+        echo "AppCleaner is already installed."
+    fi
+fi


### PR DESCRIPTION
Add script to install AppCleaner on macOS using Homebrew.

* Create `script/install.d/76-appcleaner.sh` to check if AppCleaner is already installed and install it if not
* Print a message indicating whether AppCleaner is already installed or has been installed

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andrejusk/dotfiles/pull/49?shareId=86e2e386-2540-4623-958a-8cfcf28e6255).